### PR TITLE
Update Host.cs

### DIFF
--- a/NativeMessaging/Host.cs
+++ b/NativeMessaging/Host.cs
@@ -67,7 +67,7 @@ namespace NativeMessaging
             char[] buffer = new char[BitConverter.ToInt32(lengthBytes, 0)];
 
             using (StreamReader reader = new StreamReader(stdin))
-                while (reader.Peek() >= 0)
+                if (reader.Peek() >= 0)
                     reader.Read(buffer, 0, buffer.Length);
 
             return JsonConvert.DeserializeObject<JObject>(new string(buffer));


### PR DESCRIPTION
if the stdin length is > 1023, the code while(reader.Peek() >= 0) doesn't let the reader.Read() finish.
Changing the line to ' if (reader.Peek() >= 0) ' allows the return statement to happen on short and long messages